### PR TITLE
fix: add conftest.py to ensure tests can import app modules

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,6 @@
+import sys
+import os
+
+
+sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
+


### PR DESCRIPTION
Adds conftest.py that puts the project root on sys.path. Fixes ModuleNotFoundError when running pytest from different directories.